### PR TITLE
Update __init__.py

### DIFF
--- a/search_sampler/__init__.py
+++ b/search_sampler/__init__.py
@@ -465,7 +465,7 @@ class SearchSampler(object):
                         # This will skip over that
                         rows.append({
                             "term": term,
-                            "timestamp": timestamp,
+                            "period": timestamp,
                             "sample": i,
                             "value": sample,
                             "query_time": query_time


### PR DESCRIPTION
Addresses compatibility issue with `searching_for_news/impute_samples.r` by renaming the `timestamp` column to `period`. Issue reference: https://github.com/pewresearch/searching_for_news/issues/1